### PR TITLE
Auto-collapse game info panel during gameplay

### DIFF
--- a/index.html
+++ b/index.html
@@ -2404,6 +2404,8 @@
                 this.dom.postBuryActions.classList.add('hidden');
                 this.updateLiveSummary();
                 this.dom.gameSummaryBox.classList.remove('hidden');
+                // Expand panel at start of hand so players can see bidding/dealer info
+                this.dom.gameSummaryBox.classList.remove('collapsed');
                 this.dom.trickArea.innerHTML = '';
                 this.dom.nestDisplay.innerHTML = '';
                 this.dom.widowOnTable.innerHTML = '';
@@ -2536,6 +2538,16 @@
             }
             
             async startTrickPlay() {
+                // Auto-collapse the game info panel to keep it out of the way during gameplay
+                const box = this.dom.gameSummaryBox;
+                if (!box.classList.contains('collapsed')) {
+                    box.classList.add('collapsed');
+                    const toggle = box.querySelector('.collapse-toggle');
+                    const header = box.querySelector('.game-summary-header');
+                    if (toggle) toggle.textContent = '+';
+                    if (header) header.classList.add('collapsed-only');
+                }
+
                 this.trickLeaderIndex = this.players.indexOf(this.highBidder);
                 this.team1Tricks = []; this.team2Tricks = [];
                 this.trickHistory = [];


### PR DESCRIPTION
The game info panel now automatically collapses when trick play begins to prevent blocking the playing area. Players can still manually expand it if needed, and it automatically expands at the start of each new hand for bidding/setup visibility.

Changes:
- Panel expands at start of new hand (visible during bidding/trump selection)
- Panel auto-collapses when startTrickPlay() is called
- Prevents 'the divorce' from staying on the table during gameplay
- Players can still manually toggle collapse/expand anytime